### PR TITLE
Fix sls content

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,24 +24,24 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
-            <version>2.3.0</version>
+            <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-json</artifactId>
-            <version>2.3.0</version>
+            <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.aliyun.openservices</groupId>
             <artifactId>aliyun-log-producer</artifactId>
-            <version>0.3.3</version>
+            <version>0.3.10</version>
         </dependency>
         <dependency>
             <groupId>com.aliyun.openservices</groupId>
             <artifactId>aliyun-log</artifactId>
-            <version>0.6.33</version>
+            <version>0.6.68</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>

--- a/src/main/java/com/aliyun/openservices/log/kafka/connect/JsonRecordConverter.java
+++ b/src/main/java/com/aliyun/openservices/log/kafka/connect/JsonRecordConverter.java
@@ -7,6 +7,7 @@ import org.apache.kafka.connect.sink.SinkRecord;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Map.Entry;
 
 public class JsonRecordConverter implements RecordConverter {
     private ObjectMapper objectMapper = new ObjectMapper();
@@ -18,8 +19,8 @@ public class JsonRecordConverter implements RecordConverter {
                     new TypeReference<Map<String, Object>>() {
                     });
             LogItem logItem = new LogItem();
-            for (Map.Entry<String, Object> entry : jsonNode.entrySet()) {
-                logItem.PushBack(entry.getKey(), String.valueOf(entry.getValue()));
+            for (Entry<String, Object> entry : jsonNode.entrySet()) {
+                logItem.PushBack(entry.getKey(), objectMapper.writeValueAsString(entry.getValue()));
             }
             return logItem;
         } catch (IOException e) {


### PR DESCRIPTION
The PR changes log content to JSON string. `String.valueOf(entry.getValue())` returns string representation of map, like  `"{a=100, b=200, c=300, d=400}"` which is inconvenient for downstream to process. 